### PR TITLE
Security Fix: Input Validation for Paddle Speed

### DIFF
--- a/pong.py
+++ b/pong.py
@@ -3,7 +3,9 @@ import sys
 
 # --- Vulnerable Input: Paddle speed from command-line ---
 try:
-    paddle_speed = int(sys.argv[1])  # ⚠️ No validation: user can input very large or negative values
+    paddle_speed = int(sys.argv[1])  # Validate input to prevent injection
+    if paddle_speed < 1 or paddle_speed > 10:
+        raise ValueError('Paddle speed must be between 1 and 10')
 except (IndexError, ValueError):
     paddle_speed = 5  # fallback default
 


### PR DESCRIPTION
Implemented input validation for paddle speed to prevent injection attacks. This change ensures that the paddle speed is within a safe range and defaults to 5 if invalid input is provided.